### PR TITLE
Fix rubygems.org profiles URL

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -265,7 +265,7 @@ class Generator
     end
 
     def rubygems_url
-      "https://rubygems.org/profile/profiles/#{u(rubygems_user)}"
+      "https://rubygems.org/profiles/#{u(rubygems_user)}"
     end
 
     def url


### PR DESCRIPTION
- wrong: https://rubygems.org/profile/profiles/okkez
- correct: https://rubygems.org/profiles/okkez

I fixed this problem.
